### PR TITLE
fix: permissions on publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   publish:


### PR DESCRIPTION
### Contain
- [x] Bugfix
- [x] Build/CI/CD

### Details
* Update publish workflow adding a new permission: `id-token: write`.
  * After failing GitHub Actions recommended adding this permission.